### PR TITLE
Fix Database Manager Not Checking Existing Data on Migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 
 # Project-specific ignores
 config/
+src/guessinggame_ttv/_version.py

--- a/src/guessinggame_ttv/database.py
+++ b/src/guessinggame_ttv/database.py
@@ -109,7 +109,7 @@ class DatabaseManager:
             self.logger.warn('Creating in-memory database, use this only for '
                              'testing')
 
-            conn = sqlite3.connect('file:testdb?mode=memory',
+            conn = sqlite3.connect('file:testdb?mode=memory&cache=shared',
                                    uri=True,
                                    detect_types=sqlite3.PARSE_DECLTYPES,
                                    check_same_thread=False,

--- a/src/guessinggame_ttv/database.py
+++ b/src/guessinggame_ttv/database.py
@@ -109,7 +109,7 @@ class DatabaseManager:
             self.logger.warn('Creating in-memory database, use this only for '
                              'testing')
 
-            conn = sqlite3.connect('file:testdb?mode=memory&cache=shared',
+            conn = sqlite3.connect('file:testdb?mode=memory',
                                    uri=True,
                                    detect_types=sqlite3.PARSE_DECLTYPES,
                                    check_same_thread=False,

--- a/src/guessinggame_ttv/database.py
+++ b/src/guessinggame_ttv/database.py
@@ -7,6 +7,36 @@ import logging
 import pathlib
 
 
+# Format:
+# tablename: schema
+DATABASE_SCHEMA: dict[str, str] = {
+    'users': '''CREATE TABLE users (
+    id INTEGER PRIMARY KEY NOT NULL UNIQUE,
+    username TEXT NOT NULL UNIQUE COLLATE NOCASE,
+    score INTEGER NOT NULL DEFAULT 0,
+    tokens INTEGER NOT NULL DEFAULT 0
+)''',
+    'redeems': '''CREATE TABLE redeems (
+    name TEXT PRIMARY KEY NOT NULL UNIQUE COLLATE NOCASE,
+    cost INTEGER NOT NULL
+)''',
+    'categories': '''CREATE TABLE categories (
+    id INTEGER PRIMARY KEY NOT NULL UNIQUE,
+    name TEXT NOT NULL UNIQUE COLLATE NOCASE
+)''',
+    'wordlist': '''CREATE TABLE wordlist(
+    id INTEGER PRIMARY KEY NOT NULL UNIQUE,
+    word TEXT NOT NULL UNIQUE COLLATE NOCASE,
+    category_id INTEGER NOT NULL REFERENCES categories(id) ON DELETE RESTRICT
+)''',
+    'meta': '''CREATE TABLE meta (
+    id INTEGER PRIMARY KEY NOT NULL UNIQUE,
+    name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+    data BLOB
+)'''
+}
+
+
 @contextmanager
 def sqlite_transaction(db: sqlite3.Connection) -> Generator[sqlite3.Cursor,
                                                             None, None]:

--- a/src/guessinggame_ttv/database.py
+++ b/src/guessinggame_ttv/database.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from packaging import version
-from typing import Tuple, Generator, Optional
+from typing import Tuple, Generator
 
 import sqlite3
 import logging
@@ -205,28 +205,17 @@ class DatabaseManager:
         self.logger.info(f'Checking for existing `{tablename}` data')
 
         table_exists = self._table_exists(tablename)
-        table_data: Optional[list[Tuple[str]]] = None
 
         if table_exists:
-            self.logger.info(f'`{tablename}` exists, grabbing old data')
+            self.logger.info(f'`{tablename}` exists, no need to rebuild')
 
-            table_data = self._copy_data(tablename)
-
-            self.logger.info(f'Deleting the old `{tablename}` table')
-
-            self._connection.execute('DROP TABLE ?', (tablename,))
+            return
 
         self.logger.info(f'Creating the `{tablename}` table')
 
         self._connection.execute(schema)
 
-        # Migrating table data should be moved to a separate function.
-        if table_data:
-            self.logger.info(f'`Copying old data back to `{tablename}`')
-
-            # TODO: This needs to grab the difference between the two schemas,
-            #       then insert into the new table the shared data from the
-            #       old table.
+        self.logger.info(f'Finished creating `{tablename}` table')
 
     def _init_users(self) -> None:
         self.logger.info('Initialising the `users` table')
@@ -235,7 +224,8 @@ class DatabaseManager:
         users_exists = self._table_exists('users')
 
         if users_exists:
-            self.logger.info('`users` exists, no need to rebuild.')
+            self.logger.info('`users` exists, no need to rebuild')
+
             return
 
         self.logger.info('Creating the `users` table')

--- a/src/guessinggame_ttv/database.py
+++ b/src/guessinggame_ttv/database.py
@@ -198,11 +198,8 @@ class DatabaseManager:
         if create_database:
             self.logger.info('Initialising database')
 
-            self._init_users()
-            self._init_redeems()
-            self._init_categories()
-            self._init_wordlist()
-            self._init_meta()
+            for tablename, schema in DATABASE_SCHEMA.items():
+                self._create_table(tablename, schema)
 
         self.logger.info('Database initialised')
         self._connection.commit()
@@ -246,117 +243,6 @@ class DatabaseManager:
         self._connection.execute(schema)
 
         self.logger.info(f'Finished creating `{tablename}` table')
-
-    def _init_users(self) -> None:
-        self.logger.info('Initialising the `users` table')
-        self.logger.info('Checking for existing `users` data')
-
-        users_exists = self._table_exists('users')
-
-        if users_exists:
-            self.logger.info('`users` exists, no need to rebuild')
-
-            return
-
-        self.logger.info('Creating the `users` table')
-
-        schema = '''CREATE TABLE users (
-    id INTEGER PRIMARY KEY NOT NULL UNIQUE,
-    username TEXT NOT NULL UNIQUE COLLATE NOCASE,
-    score INTEGER NOT NULL DEFAULT 0,
-    tokens INTEGER NOT NULL DEFAULT 0
-)'''
-        self._connection.execute(schema)
-
-        self.logger.info('Finished creating `users` table')
-
-    def _init_redeems(self) -> None:
-        self.logger.info('Initialising `redeems` table')
-        self.logger.info('Checking for existing `redeems` table')
-
-        redeems_exists = self._table_exists('redeems')
-
-        if redeems_exists:
-            self.logger.info('`redeems` exists, no need to rebuild')
-
-            return
-
-        self.logger.info('Creating `redeems` table')
-
-        schema = '''CREATE TABLE redeems (
-    name TEXT PRIMARY KEY NOT NULL UNIQUE COLLATE NOCASE,
-    cost INTEGER NOT NULL
-)'''
-        self._connection.execute(schema)
-
-        self.logger.info('Finished creating `redeems` table')
-
-    def _init_categories(self) -> None:
-        self.logger.info('Initialising `categories` table')
-        self.logger.info('Checking if `categories` exists')
-
-        cats_exists = self._table_exists('categories')
-
-        if cats_exists:
-            self.logger.info('`categories` exists, no need to rebuild')
-
-            return
-
-        self.logger.info('Creating `categories` table')
-
-        schema = '''CREATE TABLE categories (
-    id INTEGER PRIMARY KEY NOT NULL UNIQUE,
-    name TEXT NOT NULL UNIQUE COLLATE NOCASE
-)'''
-        self._connection.execute(schema)
-
-        self.logger.info('Finished creating `categories` table')
-
-    def _init_wordlist(self) -> None:
-        self.logger.info('Initialising `wordlist` table')
-        self.logger.info('Checking for existing `wordlist` table')
-
-        wordlist_exists = self._table_exists('wordlist')
-
-        if wordlist_exists:
-            self.logger.info('`wordlist` exists, no need to rebuild')
-
-            return
-
-        self.logger.info('Creating `wordlist` table')
-
-        schema = '''CREATE TABLE wordlist(
-    id INTEGER PRIMARY KEY NOT NULL UNIQUE,
-    word TEXT NOT NULL UNIQUE COLLATE NOCASE,
-    category_id INTEGER NOT NULL REFERENCES categories(id) ON DELETE RESTRICT
-)'''
-        self._connection.execute(schema)
-
-        self.logger.info('Finished creating `wordlist` table')
-
-    def _init_meta(self) -> None:
-        self.logger.info('Initialising `meta` table')
-        self.logger.info('Checking for existing `meta` table')
-
-        meta_exists = self._table_exists('meta')
-
-        if meta_exists:
-            self.logger.info('`meta` exists, no need to rebuild')
-
-            return
-
-        self.logger.info('Creating `meta` table')
-
-        schema = '''CREATE TABLE meta (
-    id INTEGER PRIMARY KEY NOT NULL UNIQUE,
-    name TEXT NOT NULL UNIQUE COLLATE NOCASE,
-    data BLOB
-)'''
-        self._connection.execute(schema)
-
-        self.set_meta('schema_version', str(self.schema_version))
-
-        self.logger.info('Finished creating `meta` table')
 
     def teardown(self) -> None:
         """Closes the database connection

--- a/src/guessinggame_ttv/database.py
+++ b/src/guessinggame_ttv/database.py
@@ -184,9 +184,9 @@ class DatabaseManager:
                     db_ver = version.Version(data)
 
                     if db_ver != self.schema_version:
-                        self.logger.info('Database out of date, flagging to '
-                                         'update')
-                        create_database = True
+                        self.logger.error('Database out of date, but migrating '
+                                          'is not supported!')
+                        raise NotImplementedError()
 
         # Force Sqlite3 to validate foreign keys
         conn.execute('PRAGMA foreign_keys = 1')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,11 +11,14 @@ from typing import Tuple
 
 logging.disable()
 
+rebuild_filled_dbmanager = True
+
 
 @pytest.fixture(scope='function')
 def dbmanager() -> DatabaseManager:
     dm = DatabaseManager(_in_memory=True)
-    return dm
+    yield dm
+    dm.teardown()
 
 
 @pytest.fixture(scope='function')
@@ -57,7 +60,7 @@ def dbmanagerfilled(dbmanager: DatabaseManager) -> DatabaseManager:
     conn.executemany('INSERT INTO meta (name, data) VALUES (?,?)',
                      metadata)
 
-    return dbmanager
+    yield dbmanager
 
 
 class DBManagerMock(DatabaseManager):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import sqlite3
 
 from typing import Tuple
+from collections.abc import Generator
 
 logging.disable()
 
@@ -15,7 +16,7 @@ rebuild_filled_dbmanager = True
 
 
 @pytest.fixture(scope='function')
-def dbmanager() -> DatabaseManager:
+def dbmanager() -> Generator[DatabaseManager, None, None]:
     dm = DatabaseManager(_in_memory=True)
     yield dm
     dm.teardown()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def dbmanagerfilled(dbmanager: DatabaseManager) -> DatabaseManager:
     conn.executemany('INSERT INTO meta (name, data) VALUES (?,?)',
                      metadata)
 
-    yield dbmanager
+    return dbmanager
 
 
 class DBManagerMock(DatabaseManager):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -574,7 +574,7 @@ def test_sqlite_transaction_multiple_transactions(
 
     # Skipping the schema information, which is now guaranteed to be in the
     # database.
-    _, test, real = dbconn.execute('SELECT name, data FROM meta').fetchall()
+    test, real = dbconn.execute('SELECT name, data FROM meta').fetchall()
     assert test[0] == 'test_meta'
     assert test[1] == 'test_value'
     assert real[0] == 'real_meta'
@@ -592,4 +592,4 @@ def test_sqlite_transaction_error(dbconn: sqlite3.Connection) -> None:
 
     results = dbconn.execute('SELECT name FROM meta').fetchone()
 
-    assert len(results[1:]) == 0
+    assert results is None


### PR DESCRIPTION
Currently the only work done is to make the tests run. However, this PR should address the following concerns:

- [x] Should the in-memory database use a shared cache? (I believe it should, revert this change)
- [ ] The Database Manager should check for existing data before attempting a migration.
- [ ] Regression tests should be added to ensure that the database only copies data when there is old data to copy.

I expect to revert the current change, but as I had already made and pushed it before realising the bigger issue here, I will leave this as a draft. Future changes will be made swiftly.